### PR TITLE
style injection on per page basis

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -74,14 +74,7 @@
                             "buildOptimizer": false,
                             "optimization": false,
                             "sourceMap": true,
-                            "namedChunks": true,
-                            "styles": [
-                                "src/keycloak-theme/assets/.keycloakify/login/resources-common/node_modules/@patternfly/patternfly/patternfly.min.css",
-                                "src/keycloak-theme/assets/.keycloakify/login/resources-common/node_modules/patternfly/dist/css/patternfly.min.css",
-                                "src/keycloak-theme/assets/.keycloakify/login/resources-common/node_modules/patternfly/dist/css/patternfly-additions.min.css",
-                                "src/keycloak-theme/assets/.keycloakify/login/css/login.css",
-                                "src/keycloak-theme/assets/.keycloakify/login/resources-common/lib/pficon/pficon.css"
-                            ]
+                            "namedChunks": true
                         }
                     },
                     "defaultConfiguration": "production"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@angular/forms": "^18.2.0",
         "@angular/platform-browser": "^18.2.0",
         "@angular/router": "^18.2.0",
-        "keycloakify": "^10.1.1",
+        "keycloakify": "^10.1.4",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0"
       },
@@ -8953,9 +8953,9 @@
       }
     },
     "node_modules/keycloakify": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/keycloakify/-/keycloakify-10.1.1.tgz",
-      "integrity": "sha512-9WEYM8H6lQOkOOGZroiBnS6XLQORCo3kA/Ohb2wF3V0rx/TC49nNYANK94Lj37T/gzIo3wy/6fpLY4oTbR+rJw==",
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/keycloakify/-/keycloakify-10.1.4.tgz",
+      "integrity": "sha512-YgroCRyh+dLS886kGFt1E1wU0U88NDi53blRryzLhbL1Pmrzp6+ZfLhqxOFBp2F8QICYOk10AlaMpzUqS54bjg==",
       "dependencies": {
         "tsafe": "^1.6.6"
       },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@angular/forms": "^18.2.0",
     "@angular/platform-browser": "^18.2.0",
     "@angular/router": "^18.2.0",
-    "keycloakify": "^10.1.1",
+    "keycloakify": "^10.1.4",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0"
   },

--- a/src/keycloak-theme/login/common/components/logout-other-sessions/logout-other-sessions.component.ts
+++ b/src/keycloak-theme/login/common/components/logout-other-sessions/logout-other-sessions.component.ts
@@ -6,6 +6,7 @@ import { KcClassPipe } from "../../pipes/classname.pipe";
     selector: "kc-logout-other-sessions",
     standalone: true,
     imports: [KcClassPipe],
+    providers: [KcClassPipe],
     changeDetection: ChangeDetectionStrategy.OnPush,
     templateUrl: "./logout-other-sessions.component.html"
 })

--- a/src/keycloak-theme/login/common/components/password-wrapper/password-wrapper.component.ts
+++ b/src/keycloak-theme/login/common/components/password-wrapper/password-wrapper.component.ts
@@ -8,6 +8,7 @@ import { I18nService } from "../../services/i18n.service";
     standalone: true,
     changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [KcClassPipe, AsyncPipe],
+    providers: [KcClassPipe],
     templateUrl: "./password-wrapper.component.html"
 })
 export class PasswordWrapperComponent implements OnInit {

--- a/src/keycloak-theme/login/common/pipes/classname.pipe.ts
+++ b/src/keycloak-theme/login/common/pipes/classname.pipe.ts
@@ -1,7 +1,8 @@
 import { Pipe, PipeTransform } from "@angular/core";
+import { ActivatedRoute } from "@angular/router";
 import { ClassKey, getKcClsx } from "keycloakify/login/lib/kcClsx";
-import * as classData from "../../../assets/theme.properties.json";
 import { CxArg } from "keycloakify/tools/clsx_withTransform";
+import * as classData from "../../../assets/theme.properties.json";
 
 @Pipe({
     name: "kcClass",
@@ -10,13 +11,15 @@ import { CxArg } from "keycloakify/tools/clsx_withTransform";
 export class KcClassPipe implements PipeTransform {
     private kcClsx?: (...args: CxArg<ClassKey>[]) => string;
 
-    constructor() {
-        this.loadClasses();
+    constructor(private route: ActivatedRoute) {
+        const doUseDefaultCss: boolean =
+            this.route.snapshot.data["doUseDefaultCss"] ?? true;
+        this.loadClasses(doUseDefaultCss);
     }
 
-    private loadClasses(): void {
+    private loadClasses(doUseDefaultCss = true): void {
         const params = {
-            doUseDefaultCss: true,
+            doUseDefaultCss,
             classes: classData
         };
         this.kcClsx = getKcClsx(params).kcClsx;

--- a/src/keycloak-theme/login/common/resolvers/stylesheet.resolver.ts
+++ b/src/keycloak-theme/login/common/resolvers/stylesheet.resolver.ts
@@ -1,0 +1,11 @@
+import { inject } from "@angular/core";
+import { ActivatedRouteSnapshot, ResolveFn } from "@angular/router";
+import { DynamicStyleLoader } from "../services/dynamic-style-loader.service";
+
+export const styleSheetResolver: ResolveFn<boolean> = (route: ActivatedRouteSnapshot) => {
+    const dynamicStyleLoader = inject(DynamicStyleLoader);
+    const doUseDefaultCss: boolean = route.data["doUseDefaultCss"] ?? true;
+    if (!doUseDefaultCss) return true;
+
+    return dynamicStyleLoader.loadStyle();
+};

--- a/src/keycloak-theme/login/common/services/dynamic-style-loader.service.ts
+++ b/src/keycloak-theme/login/common/services/dynamic-style-loader.service.ts
@@ -1,13 +1,49 @@
-import { inject, Injectable, Renderer2, RendererFactory2 } from "@angular/core";
-import { Observable } from "rxjs";
+import {
+    inject,
+    Injectable,
+    isDevMode,
+    Renderer2,
+    RendererFactory2
+} from "@angular/core";
+import { KcContext } from "keycloakify/login/KcContext";
+import { catchError, forkJoin, Observable, of, switchMap } from "rxjs";
+import { KC_CONTEXT } from "../providers/keycloak-context.provider";
 
 @Injectable({
     providedIn: "root"
 })
 export class DynamicStyleLoader {
     private renderer: Renderer2 = inject(RendererFactory2).createRenderer(null, null);
-    loadStyle(url: string): Observable<void> {
+    kcContext: KcContext = inject(KC_CONTEXT);
+    loadStyle() {
+        let stylesheets = [
+            `${this.kcContext.url.resourcesCommonPath}/node_modules/@patternfly/patternfly/patternfly.min.css`,
+            `${this.kcContext.url.resourcesCommonPath}/node_modules/patternfly/dist/css/patternfly.min.css`,
+            `${this.kcContext.url.resourcesCommonPath}/node_modules/patternfly/dist/css/patternfly-additions.min.css`,
+            `${this.kcContext.url.resourcesCommonPath}/lib/pficon/pficon.css`,
+            `${this.kcContext.url.resourcesPath}/css/login.css`
+        ];
+        if (isDevMode()) {
+            stylesheets = stylesheets.map(s => `/static/media${s}`);
+        }
+
+        return forkJoin(stylesheets.map(url => this.createLink(url))).pipe(
+            switchMap(() => of(true)),
+            catchError(error => {
+                console.error("Error loading styles:", error);
+                return of(false);
+            })
+        );
+    }
+    private createLink(url: string): Observable<void> {
         return new Observable<void>(observer => {
+            // check if the style is already injected
+            if (Array.from(document.styleSheets).some(s => s.href?.includes(url))) {
+                observer.next();
+                observer.complete();
+                console.debug(`stylesheet: ${url} already loaded`);
+                return;
+            }
             const link = document.createElement("link");
             link.rel = "stylesheet";
             link.href = url;

--- a/src/keycloak-theme/login/login.routes.ts
+++ b/src/keycloak-theme/login/login.routes.ts
@@ -1,4 +1,5 @@
 import { Route } from "@angular/router";
+import { styleSheetResolver } from "./common/resolvers/stylesheet.resolver";
 
 export const LOGIN_ROUTES: Route[] = [
     {
@@ -7,33 +8,43 @@ export const LOGIN_ROUTES: Route[] = [
             {
                 path: "login",
                 loadComponent: () =>
-                    import("./pages/login/login.component").then(m => m.LoginComponent)
+                    import("./pages/login/login.component").then(m => m.LoginComponent),
+                data: { doUseDefaultCss: true },
+                resolve: { styleSheetResolver }
             },
             {
                 path: "register",
                 loadComponent: () =>
                     import("./pages/register/register.component").then(
                         m => m.RegisterComponent
-                    )
+                    ),
+                data: { doUseDefaultCss: true },
+                resolve: { styleSheetResolver }
             },
             {
                 path: "error",
                 loadComponent: () =>
-                    import("./pages/error/error.component").then(m => m.ErrorComponent)
+                    import("./pages/error/error.component").then(m => m.ErrorComponent),
+                data: { doUseDefaultCss: true },
+                resolve: { styleSheetResolver }
             },
             {
                 path: "login-reset-password",
                 loadComponent: () =>
                     import(
                         "./pages/login-reset-password/login-reset-password.component"
-                    ).then(m => m.LoginResetPasswordComponent)
+                    ).then(m => m.LoginResetPasswordComponent),
+                data: { doUseDefaultCss: true },
+                resolve: { styleSheetResolver }
             },
             {
                 path: "login-update-password",
                 loadComponent: () =>
                     import(
                         "./pages/login-update-password/login-update-password.component"
-                    ).then(m => m.LoginUpdatePasswordComponent)
+                    ).then(m => m.LoginUpdatePasswordComponent),
+                data: { doUseDefaultCss: true },
+                resolve: { styleSheetResolver }
             },
             {
                 path: "**",

--- a/src/keycloak-theme/login/pages/error/error.component.ts
+++ b/src/keycloak-theme/login/pages/error/error.component.ts
@@ -10,7 +10,7 @@ import { KC_CONTEXT } from "../../common/providers/keycloak-context.provider";
     selector: "kc-error",
     standalone: true,
     imports: [KcClassPipe, AsyncPipe],
-    providers: [ActivatedRoute],
+    providers: [KcClassPipe],
     changeDetection: ChangeDetectionStrategy.OnPush,
     templateUrl: "./error.component.html"
 })

--- a/src/keycloak-theme/login/pages/login-reset-password/login-reset-password.component.ts
+++ b/src/keycloak-theme/login/pages/login-reset-password/login-reset-password.component.ts
@@ -12,6 +12,7 @@ import { TemplateComponent } from "../../template.component";
     standalone: true,
     changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [KcClassPipe, AsyncPipe, SanitizeHtmlPipe, TemplateComponent],
+    providers: [KcClassPipe],
     templateUrl: "./login-reset-password.component.html"
 })
 export class LoginResetPasswordComponent {

--- a/src/keycloak-theme/login/pages/login-update-password/login-update-password.component.ts
+++ b/src/keycloak-theme/login/pages/login-update-password/login-update-password.component.ts
@@ -19,6 +19,7 @@ import { I18nService } from "../../common/services/i18n.service";
         CommonModule,
         LogoutOtherSessionsComponent
     ],
+    providers: [KcClassPipe],
     templateUrl: "./login-update-password.component.html"
 })
 export class LoginUpdatePasswordComponent {

--- a/src/keycloak-theme/login/pages/login/login.component.ts
+++ b/src/keycloak-theme/login/pages/login/login.component.ts
@@ -20,7 +20,8 @@ import { TemplateComponent } from "../../template.component";
         PasswordWrapperComponent,
         NgClass,
         TemplateComponent
-    ]
+    ],
+    providers: [KcClassPipe]
 })
 export class LoginComponent {
     kcContext = inject<Extract<KcContext, { pageId: "login.ftl" }>>(KC_CONTEXT);

--- a/src/keycloak-theme/login/pages/register/register.component.ts
+++ b/src/keycloak-theme/login/pages/register/register.component.ts
@@ -10,7 +10,8 @@ import { I18nService } from "../../common/services/i18n.service";
     standalone: true,
     templateUrl: "./register.component.html",
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [KcClassPipe, AsyncPipe]
+    imports: [KcClassPipe, AsyncPipe],
+    providers: [KcClassPipe]
 })
 export class RegisterComponent {
     kcContext = inject<Extract<KcContext, { pageId: "register.ftl" }>>(KC_CONTEXT);

--- a/src/keycloak-theme/login/template.component.html
+++ b/src/keycloak-theme/login/template.component.html
@@ -1,7 +1,6 @@
 @let i18n = i18nService.i18n$ | async;
-@let stylesheetsLoaded = stylesheetsLoaded$ | async;
 
-@if (i18n && stylesheetsLoaded) {
+@if (i18n) {
     <div [class]="'kcLoginClass' | kcClass">
         <div id="kc-header" [class]="'kcHeaderClass' | kcClass">
             <div id="kc-header-wrapper" [class]="'kcHeaderWrapperClass' | kcClass">

--- a/src/keycloak-theme/login/template.component.ts
+++ b/src/keycloak-theme/login/template.component.ts
@@ -4,27 +4,15 @@ import {
     Component,
     inject,
     input,
-    isDevMode,
-    OnDestroy,
     OnInit,
     Renderer2
 } from "@angular/core";
-import { RouterLink, RouterLinkActive } from "@angular/router";
+import { ActivatedRoute, RouterLink, RouterLinkActive } from "@angular/router";
 import { PUBLIC_URL } from "keycloakify/PUBLIC_URL";
 import { KcContext } from "keycloakify/login/KcContext/KcContext";
-import {
-    catchError,
-    forkJoin,
-    NEVER,
-    Observable,
-    of,
-    switchMap,
-    Unsubscribable
-} from "rxjs";
 import { KcClassPipe } from "./common/pipes/classname.pipe";
 import { SanitizeHtmlPipe } from "./common/pipes/sanitize-html.pipe";
 import { KC_CONTEXT } from "./common/providers/keycloak-context.provider";
-import { DynamicStyleLoader } from "./common/services/dynamic-style-loader.service";
 import { I18nService } from "./common/services/i18n.service";
 
 @Component({
@@ -42,22 +30,18 @@ import { I18nService } from "./common/services/i18n.service";
     changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [KcClassPipe]
 })
-export class TemplateComponent implements OnInit, OnDestroy {
-    stylesheetsLoaded$: Observable<boolean> | undefined;
+export class TemplateComponent implements OnInit {
     kcContext: KcContext = inject(KC_CONTEXT);
     i18nService = inject(I18nService);
     renderer = inject(Renderer2);
     private kcClassPipe = inject(KcClassPipe);
-    private dynamicStyleLoader = inject(DynamicStyleLoader);
     displayRequiredFields = false;
+    route = inject(ActivatedRoute);
 
     displayInfo = input(true);
     displayMessage = input(true);
 
-    subscription: Unsubscribable | undefined;
-
     ngOnInit() {
-        this.loadStyles();
         this.applyKcIndexClasses();
     }
 
@@ -76,40 +60,11 @@ export class TemplateComponent implements OnInit, OnDestroy {
         });
     }
 
-    private loadStyles(): void {
-        if (isDevMode()) {
-            this.stylesheetsLoaded$ = of(true);
-            return;
-        }
-
-        const stylesheets = [
-            `${this.kcContext.url.resourcesCommonPath}/node_modules/@patternfly/patternfly/patternfly.min.css`,
-            `${this.kcContext.url.resourcesCommonPath}/node_modules/patternfly/dist/css/patternfly.min.css`,
-            `${this.kcContext.url.resourcesCommonPath}/node_modules/patternfly/dist/css/patternfly-additions.min.css`,
-            `${this.kcContext.url.resourcesCommonPath}/lib/pficon/pficon.css`,
-            `${this.kcContext.url.resourcesPath}/css/login.css`
-        ];
-
-        this.stylesheetsLoaded$ = forkJoin(
-            stylesheets.map(url => this.dynamicStyleLoader.loadStyle(url))
-        ).pipe(
-            switchMap(() => of(true)),
-            catchError(error => {
-                console.error("Error loading styles:", error);
-                return NEVER;
-            })
-        );
-    }
-
     tryAnotherWay() {
         document.forms["kc-select-try-another-way-form" as never].submit();
     }
 
     get publicUrl() {
         return PUBLIC_URL;
-    }
-
-    ngOnDestroy(): void {
-        this.subscription?.unsubscribe();
     }
 }


### PR DESCRIPTION
in login.routes we can define if we want to use default css on per page basis using: `data: { doUseDefaultCss: true },`
this value is saved on `ActivatedRouteSnapshot` and can be read in `styleSheetResolver` and `KcClassPipe`